### PR TITLE
add compiler options for more some extra warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,6 +5,7 @@ project(rotconv)
 # Enable C++11
 message(STATUS "Enabling C++11")
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
+add_compile_options(-Wall -Wextra -Wpedantic)
 
 # Find Eigen
 find_package(Eigen3 REQUIRED)

--- a/include/rot_conv/rot_conv.h
+++ b/include/rot_conv/rot_conv.h
@@ -512,23 +512,23 @@ namespace rot_conv
 	namespace internal
 	{
 		// Compose: Rotation matrix
-		inline void ComposeRotmatHelper(Rotmat& Rout) {}
+		inline void ComposeRotmatHelper(Rotmat&) {}
 		template<typename... Types> void ComposeRotmatHelper(Rotmat& Rout, const Rotmat& R, Types&&... args);
 
 		// Compose: Quaternion
-		inline void ComposeQuatHelper(Quat& qout) {}
+		inline void ComposeQuatHelper(Quat&) {}
 		template<typename... Types> void ComposeQuatHelper(Quat& qout, const Quat& q, Types&&... args);
 
 		// Compose: Euler angles
-		inline void ComposeEulerHelper(Rotmat& Rout) {}
+		inline void ComposeEulerHelper(Rotmat&) {}
 		template<typename... Types> void ComposeEulerHelper(Rotmat& Rout, const EulerAngles& e, Types&&... args);
 
 		// Compose: Fused angles
-		inline void ComposeFusedHelper(Rotmat& Rout) {}
+		inline void ComposeFusedHelper(Rotmat&) {}
 		template<typename... Types> void ComposeFusedHelper(Rotmat& Rout, const FusedAngles& f, Types&&... args);
 
 		// Compose: Tilt angles
-		inline void ComposeTiltHelper(Rotmat& Rout) {}
+		inline void ComposeTiltHelper(Rotmat&) {}
 		template<typename... Types> void ComposeTiltHelper(Rotmat& Rout, const TiltAngles& t, Types&&... args);
 	}
 
@@ -1034,14 +1034,14 @@ namespace rot_conv
 	namespace internal
 	{
 		// Sum of tilt phases
-		inline void TiltPhaseSumHelper(TiltPhase2D& pout) {}
-		inline void TiltPhaseSumHelper(TiltPhase3D& pout) {}
+		inline void TiltPhaseSumHelper(TiltPhase2D&) {}
+		inline void TiltPhaseSumHelper(TiltPhase3D&) {}
 		template<typename... Types> void TiltPhaseSumHelper(TiltPhase2D& pout, const TiltPhase2D& p, Types&&... args);
 		template<typename... Types> void TiltPhaseSumHelper(TiltPhase3D& pout, const TiltPhase3D& p, Types&&... args);
 
 		// Sum of tilt phase velocities
-		inline void TiltPhaseVelSumHelper(TiltPhaseVel2D& pdotout) {}
-		inline void TiltPhaseVelSumHelper(TiltPhaseVel3D& pdotout) {}
+		inline void TiltPhaseVelSumHelper(TiltPhaseVel2D&) {}
+		inline void TiltPhaseVelSumHelper(TiltPhaseVel3D&) {}
 		template<typename... Types> void TiltPhaseVelSumHelper(TiltPhaseVel2D& pdotout, const TiltPhaseVel2D& pdot, Types&&... args);
 		template<typename... Types> void TiltPhaseVelSumHelper(TiltPhaseVel3D& pdotout, const TiltPhaseVel3D& pdot, Types&&... args);
 	}

--- a/test/rot_conv_sample.cpp
+++ b/test/rot_conv_sample.cpp
@@ -11,7 +11,7 @@
 using namespace rot_conv;
 
 // Main function
-int main(int argc, char **argv)
+int main(int, char **)
 {
 	// Initialise random numbers
 	std::srand(std::time(0));


### PR DESCRIPTION
Thank you for providing this open source library.

When including rotconv header files in a project that enforces `-Wextra`, warnings (or errors if using -Werror) arise. Although this is a project-specific issue, it probably would arise quite frequently.

Fixing these here would save users from the inconvenience of figuring out work arounds (although possible).

Warnings produced by adding the compile options:

```
In file included from /home/ijnek/Downloads/tmp/humanoid_base_footprint_ws/src/humanoid_base_footprint/src/base_footprint.cpp:15:
/home/ijnek/Downloads/tmp/humanoid_base_footprint_ws/install/rotconv/include/rot_conv/rot_conv.h: In function ‘void rot_conv::internal::ComposeRotmatHelper(rot_conv::Rotmat&)’:
/home/ijnek/Downloads/tmp/humanoid_base_footprint_ws/install/rotconv/include/rot_conv/rot_conv.h:515:43: warning: unused parameter ‘Rout’ [-Wunused-parameter]
  515 |   inline void ComposeRotmatHelper(Rotmat& Rout) {}
      |                                   ~~~~~~~~^~~~
/home/ijnek/Downloads/tmp/humanoid_base_footprint_ws/install/rotconv/include/rot_conv/rot_conv.h: In function ‘void rot_conv::internal::ComposeQuatHelper(rot_conv::Quat&)’:
/home/ijnek/Downloads/tmp/humanoid_base_footprint_ws/install/rotconv/include/rot_conv/rot_conv.h:519:39: warning: unused parameter ‘qout’ [-Wunused-parameter]
  519 |   inline void ComposeQuatHelper(Quat& qout) {}
      |                                 ~~~~~~^~~~
/home/ijnek/Downloads/tmp/humanoid_base_footprint_ws/install/rotconv/include/rot_conv/rot_conv.h: In function ‘void rot_conv::internal::ComposeEulerHelper(rot_conv::Rotmat&)’:
/home/ijnek/Downloads/tmp/humanoid_base_footprint_ws/install/rotconv/include/rot_conv/rot_conv.h:523:42: warning: unused parameter ‘Rout’ [-Wunused-parameter]
  523 |   inline void ComposeEulerHelper(Rotmat& Rout) {}
      |                                  ~~~~~~~~^~~~
/home/ijnek/Downloads/tmp/humanoid_base_footprint_ws/install/rotconv/include/rot_conv/rot_conv.h: In function ‘void rot_conv::internal::ComposeFusedHelper(rot_conv::Rotmat&)’:
/home/ijnek/Downloads/tmp/humanoid_base_footprint_ws/install/rotconv/include/rot_conv/rot_conv.h:527:42: warning: unused parameter ‘Rout’ [-Wunused-parameter]
  527 |   inline void ComposeFusedHelper(Rotmat& Rout) {}
      |                                  ~~~~~~~~^~~~
/home/ijnek/Downloads/tmp/humanoid_base_footprint_ws/install/rotconv/include/rot_conv/rot_conv.h: In function ‘void rot_conv::internal::ComposeTiltHelper(rot_conv::Rotmat&)’:
/home/ijnek/Downloads/tmp/humanoid_base_footprint_ws/install/rotconv/include/rot_conv/rot_conv.h:531:41: warning: unused parameter ‘Rout’ [-Wunused-parameter]
  531 |   inline void ComposeTiltHelper(Rotmat& Rout) {}
      |                                 ~~~~~~~~^~~~
/home/ijnek/Downloads/tmp/humanoid_base_footprint_ws/install/rotconv/include/rot_conv/rot_conv.h: In function ‘void rot_conv::internal::TiltPhaseSumHelper(rot_conv::TiltPhase2D&)’:
/home/ijnek/Downloads/tmp/humanoid_base_footprint_ws/install/rotconv/include/rot_conv/rot_conv.h:1037:47: warning: unused parameter ‘pout’ [-Wunused-parameter]
 1037 |   inline void TiltPhaseSumHelper(TiltPhase2D& pout) {}
      |                                  ~~~~~~~~~~~~~^~~~
/home/ijnek/Downloads/tmp/humanoid_base_footprint_ws/install/rotconv/include/rot_conv/rot_conv.h: In function ‘void rot_conv::internal::TiltPhaseSumHelper(rot_conv::TiltPhase3D&)’:
/home/ijnek/Downloads/tmp/humanoid_base_footprint_ws/install/rotconv/include/rot_conv/rot_conv.h:1038:47: warning: unused parameter ‘pout’ [-Wunused-parameter]
 1038 |   inline void TiltPhaseSumHelper(TiltPhase3D& pout) {}
      |                                  ~~~~~~~~~~~~~^~~~
/home/ijnek/Downloads/tmp/humanoid_base_footprint_ws/install/rotconv/include/rot_conv/rot_conv.h: In function ‘void rot_conv::internal::TiltPhaseVelSumHelper(rot_conv::TiltPhaseVel2D&)’:
/home/ijnek/Downloads/tmp/humanoid_base_footprint_ws/install/rotconv/include/rot_conv/rot_conv.h:1043:53: warning: unused parameter ‘pdotout’ [-Wunused-parameter]
 1043 |   inline void TiltPhaseVelSumHelper(TiltPhaseVel2D& pdotout) {}
      |                                     ~~~~~~~~~~~~~~~~^~~~~~~
/home/ijnek/Downloads/tmp/humanoid_base_footprint_ws/install/rotconv/include/rot_conv/rot_conv.h: In function ‘void rot_conv::internal::TiltPhaseVelSumHelper(rot_conv::TiltPhaseVel3D&)’:
/home/ijnek/Downloads/tmp/humanoid_base_footprint_ws/install/rotconv/include/rot_conv/rot_conv.h:1044:53: warning: unused parameter ‘pdotout’ [-Wunused-parameter]
 1044 |   inline void TiltPhaseVelSumHelper(TiltPhaseVel3D& pdotout) {}
      |                                     ~~~~~~~~~~~~~~~~^~~~~~~
```