### PR TITLE
Bump cmake_minimum_required to 2.8.12

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 # Rotations Conversion Library project
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 2.8.12)
 project(rotconv)
 
 # Enable C++11


### PR DESCRIPTION
This change prevents a deprecation warning that arises since CMake3.19.1:

```
CMake Deprecation Warning at CMakeLists.txt:2 (cmake_minimum_required):
  Compatibility with CMake < 2.8.12 will be removed from a future version of
  CMake.

  Update the VERSION argument <min> value or use a ...<max> suffix to tell
  CMake that the project does not need compatibility with older versions.
```

Similar PR has been raised and merged in [facebook/zstd](https://github.com/facebook/zstd/pull/2399).